### PR TITLE
Feature/make configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,3 +30,26 @@ Call the directive with path to python module as content. The ``:classes:`` and
         :packages:
 
 Requires pyreverse from pylint.
+
+Options
+^^^^^^^
+
+To configure usage, in your conf.py
+
+* ``sphinx_pyreverse_output`` (see --output), default is "png"
+* ``sphinx_pyreverse_filter_mode`` (see --filter_mode), default is None
+* ``sphinx_pyreverse_class`` (see --class), default is None
+* ``sphinx_pyreverse_show_ancestors`` (see --show_ancestors), default is None
+* ``sphinx_pyreverse_all_ancestors`` (see --all_ancestors), default is None
+* ``sphinx_pyreverse_show_associated`` (see --show_associated), default is None
+* ``sphinx_pyreverse_all_associated`` (see --all_associated), default is None
+* ``sphinx_pyreverse_show_builtin`` (see --show_builtin), default is None
+* ``sphinx_pyreverse_module_names`` (see --module_names), default is None
+* ``sphinx_pyreverse_only_classnames`` (see --only_classnames), default is None
+* ``sphinx_pyreverse_ignore`` (see --ignore), default is None
+
+Changing the directive
+^^^^^^^^^^^^^^^^^^^^^^
+
+To override the directive, which defaults to 'uml' set the
+``SPHINX_PYREVERSE_DIRECTIVE`` environment variable to whatever you like.

--- a/pip-requirements-test
+++ b/pip-requirements-test
@@ -4,3 +4,4 @@ mock
 docutils
 flake8
 pylint
+sphinx

--- a/scripts/runners/run_test.sh
+++ b/scripts/runners/run_test.sh
@@ -34,17 +34,6 @@ if [ $EXIT_CODE -ne 0 ]; then
 	exit $EXIT_CODE
 fi
 
-# Get the coverage percentage
-COVERAGE=$(coverage report --rcfile=.coveragerc -m --omit=*python*-packages* | grep "TOTAL.\+" | awk '{print $6}')
-if [ "$COVERAGE" != "100%" ]; then
-	# if we only have a single file we need to look at that file only
-	COVERAGE=$(coverage report --rcfile=.coveragerc -m --omit=*python*-packages* | grep "%" | awk '{print $6}')
-	if [ "$COVERAGE" != "100%" ]; then
-		printf "COVERAGE: Failed: '%s' is not '100%%' \\n" "$COVERAGE"
-		exit 2
-	fi
-fi
-
 # Checks the syntax of all the files match the standards
 python -m flake8 $PYTHON_FILES
 EXIT_CODE=$?
@@ -59,4 +48,15 @@ EXIT_CODE=$?
 if [ $EXIT_CODE -ne 0 ]; then
 	printf "pylint: Failed\\n"
 	exit $EXIT_CODE
+fi
+
+# Get the coverage percentage
+COVERAGE=$(coverage report --rcfile=.coveragerc -m --omit=*python*-packages* | grep "TOTAL.\+" | awk '{print $6}')
+if [ "$COVERAGE" != "100%" ]; then
+	# if we only have a single file we need to look at that file only
+	COVERAGE=$(coverage report --rcfile=.coveragerc -m --omit=*python*-packages* | grep "%" | awk '{print $6}')
+	if [ "$COVERAGE" != "100%" ]; then
+		printf "COVERAGE: Failed: '%s' is not '100%%' \\n" "$COVERAGE"
+		exit 2
+	fi
 fi

--- a/sphinx_pyreverse/__init__.py
+++ b/sphinx_pyreverse/__init__.py
@@ -13,6 +13,20 @@ from .uml_generate_directive import UMLGenerateDirective
 def setup(app):
     """Setup directive"""
     app.add_config_value("sphinx_pyreverse_output", default="png", rebuild="env")
+    app.add_config_value("sphinx_pyreverse_filter_mode", default=None, rebuild="env")
+    app.add_config_value("sphinx_pyreverse_class", default=None, rebuild="env")
+    app.add_config_value("sphinx_pyreverse_show_ancestors", default=None, rebuild="env")
+    app.add_config_value("sphinx_pyreverse_all_ancestors", default=None, rebuild="env")
+    app.add_config_value(
+        "sphinx_pyreverse_show_associated", default=None, rebuild="env"
+    )
+    app.add_config_value("sphinx_pyreverse_all_associated", default=None, rebuild="env")
+    app.add_config_value("sphinx_pyreverse_show_builtin", default=None, rebuild="env")
+    app.add_config_value("sphinx_pyreverse_module_names", default=None, rebuild="env")
+    app.add_config_value(
+        "sphinx_pyreverse_only_classnames", default=None, rebuild="env"
+    )
+    app.add_config_value("sphinx_pyreverse_ignore", default=None, rebuild="env")
 
     # Allow override of the directive, defaulting to 'uml'
     directive_name_to_use = os.environ.get("SPHINX_PYREVERSE_DIRECTIVE", "uml")

--- a/sphinx_pyreverse/__init__.py
+++ b/sphinx_pyreverse/__init__.py
@@ -3,6 +3,7 @@ Created on Oct 1, 2012
 
 @author: alendit
 """
+import os
 
 __all__ = ["UMLGenerateDirective"]
 
@@ -11,4 +12,6 @@ from .uml_generate_directive import UMLGenerateDirective
 
 def setup(app):
     """Setup directive"""
-    app.add_directive("uml", UMLGenerateDirective)
+    # Allow override of the directive, defaulting to 'uml'
+    directive_name_to_use = os.environ.get("SPHINX_PYREVERSE_DIRECTIVE", "uml")
+    app.add_directive(directive_name_to_use, UMLGenerateDirective)

--- a/sphinx_pyreverse/__init__.py
+++ b/sphinx_pyreverse/__init__.py
@@ -12,6 +12,8 @@ from .uml_generate_directive import UMLGenerateDirective
 
 def setup(app):
     """Setup directive"""
+    app.add_config_value("sphinx_pyreverse_output", default="png", rebuild="env")
+
     # Allow override of the directive, defaulting to 'uml'
     directive_name_to_use = os.environ.get("SPHINX_PYREVERSE_DIRECTIVE", "uml")
     app.add_directive(directive_name_to_use, UMLGenerateDirective)

--- a/sphinx_pyreverse/uml_generate_directive.py
+++ b/sphinx_pyreverse/uml_generate_directive.py
@@ -51,11 +51,11 @@ class UMLGenerateDirective(Directive):
                 )
             )
 
-    def _build_command(self, module_name):
+    def _build_command(self, module_name, config):
         cmd = [
             "pyreverse",
             "--output",
-            "png",
+            config.sphinx_pyreverse_output,
             "--project",
             module_name,
         ]
@@ -82,7 +82,7 @@ class UMLGenerateDirective(Directive):
         self._validate()
 
         if module_name not in self.generated_modules:
-            cmd = self._build_command(module_name)
+            cmd = self._build_command(module_name, env.config)
             logging.getLogger(__name__).info("Running: {cmd}".format(cmd=" ".join(cmd)))
             try:
                 subprocess.check_output(
@@ -97,14 +97,16 @@ class UMLGenerateDirective(Directive):
         res = []
         for arg in self.arguments[1:]:
             img_name = arg.strip(":")
-            res.append(self.generate_img(img_name, module_name, base_dir, src_dir))
+            res.append(
+                self.generate_img(img_name, module_name, base_dir, src_dir, env.config)
+            )
 
         return res
 
-    def generate_img(self, img_name, module_name, base_dir, src_dir):
+    def generate_img(self, img_name, module_name, base_dir, src_dir, config):
         """ Resizes the image and returns a Sphinx image """
-        path_from_base = os.path.join(self.DIR_NAME, "{1}_{0}.png").format(
-            module_name, img_name
+        path_from_base = os.path.join(self.DIR_NAME, "{1}_{0}.{2}").format(
+            module_name, img_name, config.sphinx_pyreverse_output
         )
         # use relpath to get sub-directory of the main 'source' location
         src_base = os.path.relpath(base_dir, start=src_dir)

--- a/sphinx_pyreverse/uml_generate_directive.py
+++ b/sphinx_pyreverse/uml_generate_directive.py
@@ -11,6 +11,7 @@ import subprocess
 
 from docutils import nodes
 from docutils.parsers.rst import directives
+from sphinx.util import logging
 
 try:
     from sphinx.util.compat import Directive
@@ -82,6 +83,7 @@ class UMLGenerateDirective(Directive):
 
         if module_name not in self.generated_modules:
             cmd = self._build_command(module_name)
+            logging.getLogger(__name__).info("Running: {cmd}".format(cmd=" ".join(cmd)))
             try:
                 subprocess.check_output(
                     cmd, cwd=uml_dir,

--- a/sphinx_pyreverse/uml_generate_directive.py
+++ b/sphinx_pyreverse/uml_generate_directive.py
@@ -50,6 +50,19 @@ class UMLGenerateDirective(Directive):
                 )
             )
 
+    def _build_command(self, module_name):
+        cmd = [
+            "pyreverse",
+            "--output",
+            "png",
+            "--project",
+            module_name,
+        ]
+
+        # finally append the module to generate the uml for
+        cmd.append(module_name)
+        return cmd
+
     def run(self):
         doc = self.state.document
         env = doc.settings.env
@@ -68,10 +81,10 @@ class UMLGenerateDirective(Directive):
         self._validate()
 
         if module_name not in self.generated_modules:
+            cmd = self._build_command(module_name)
             try:
                 subprocess.check_output(
-                    ["pyreverse", "-o", "png", "-p", module_name, module_name],
-                    cwd=uml_dir,
+                    cmd, cwd=uml_dir,
                 )
             except subprocess.CalledProcessError as error:
                 print(error.output)

--- a/sphinx_pyreverse/uml_generate_directive.py
+++ b/sphinx_pyreverse/uml_generate_directive.py
@@ -51,7 +51,7 @@ class UMLGenerateDirective(Directive):
                 )
             )
 
-    def _build_command(self, module_name, config):
+    def _build_command(self, module_name, config):  # noqa: C901 func too-complex
         cmd = [
             "pyreverse",
             "--output",
@@ -59,6 +59,27 @@ class UMLGenerateDirective(Directive):
             "--project",
             module_name,
         ]
+        if config.sphinx_pyreverse_filter_mode:
+            assert config.sphinx_pyreverse_filter_mode
+            cmd.extend(("--filter-mode", config.sphinx_pyreverse_filter_mode))
+        if config.sphinx_pyreverse_class:
+            cmd.extend(("--class", config.sphinx_pyreverse_class))
+        if config.sphinx_pyreverse_show_ancestors:
+            cmd.extend(("--show-ancestors", config.sphinx_pyreverse_show_ancestors))
+        if config.sphinx_pyreverse_all_ancestors:
+            cmd.append("--all-ancestors")
+        if config.sphinx_pyreverse_show_associated:
+            cmd.extend(("--show-associated", config.sphinx_pyreverse_show_associated))
+        if config.sphinx_pyreverse_all_associated:
+            cmd.append("--all-associated")
+        if config.sphinx_pyreverse_show_builtin:
+            cmd.append("--show-builtin")
+        if config.sphinx_pyreverse_module_names:
+            cmd.extend(("--module-names", config.sphinx_pyreverse_module_names))
+        if config.sphinx_pyreverse_only_classnames:
+            cmd.append("--only-classnames")
+        if config.sphinx_pyreverse_ignore:
+            cmd.extend(("--ignore", config.sphinx_pyreverse_ignore))
 
         # finally append the module to generate the uml for
         cmd.append(module_name)

--- a/test/mock_pil.py
+++ b/test/mock_pil.py
@@ -45,6 +45,8 @@ def _open(_):
     class MockImage(object):
         """ A MockImage with a mock size """
 
+        __slots__ = ("size",)
+
         def __init__(self):
             self.size = _DIMS_UNDER_TEST
 

--- a/test/mock_subprocess.py
+++ b/test/mock_subprocess.py
@@ -8,6 +8,7 @@ Created on Oct 8, 2019
 """
 import sys
 import types
+from mock import MagicMock
 
 
 _CHECK_OUTPUT_FAILS = False
@@ -58,3 +59,6 @@ SUBPROCESS_MOCK = types.ModuleType(SUBPROCESS_MODULE_NAME)
 sys.modules[SUBPROCESS_MODULE_NAME] = SUBPROCESS_MOCK
 SUBPROCESS_MOCK.check_output = failing_call
 SUBPROCESS_MOCK.CalledProcessError = CalledProcessError
+SUBPROCESS_MOCK.PIPE = MagicMock()
+SUBPROCESS_MOCK.STDOUT = MagicMock()
+SUBPROCESS_MOCK.DEVNULL = MagicMock()

--- a/test/sphinx_test_util.py
+++ b/test/sphinx_test_util.py
@@ -7,9 +7,15 @@ Created on 22, 2020
 """
 
 
+class MockConfig(object):  # pylint: disable=missing-docstring
+    def __init__(self):  # pylint: disable=missing-docstring
+        self.sphinx_pyreverse_output = "png"
+
+
 class MockEnv(object):  # pylint: disable=missing-docstring
     def __init__(self):  # pylint: disable=missing-docstring
         self.srcdir = "."
+        self.config = MockConfig()
 
 
 class MockDocSettings(object):  # pylint: disable=missing-docstring

--- a/test/sphinx_test_util.py
+++ b/test/sphinx_test_util.py
@@ -1,0 +1,28 @@
+"""
+Defines mocks objects mimicing sphinx applications state for tests
+
+Created on 22, 2020
+
+@author: doublethefish
+"""
+
+
+class MockEnv(object):  # pylint: disable=missing-docstring
+    def __init__(self):  # pylint: disable=missing-docstring
+        self.srcdir = "."
+
+
+class MockDocSettings(object):  # pylint: disable=missing-docstring
+    def __init__(self):  # pylint: disable=missing-docstring
+        self.env = MockEnv()
+
+
+class MockDoc(object):  # pylint: disable=missing-docstring
+    def __init__(self):  # pylint: disable=missing-docstring
+        self.settings = MockDocSettings()
+        self.current_source = "."
+
+
+class MockState(object):  # pylint: disable=missing-docstring
+    def __init__(self):  # pylint: disable=missing-docstring
+        self.document = MockDoc()

--- a/test/sphinx_test_util.py
+++ b/test/sphinx_test_util.py
@@ -10,6 +10,16 @@ Created on 22, 2020
 class MockConfig(object):  # pylint: disable=missing-docstring
     def __init__(self):  # pylint: disable=missing-docstring
         self.sphinx_pyreverse_output = "png"
+        self.sphinx_pyreverse_filter_mode = None
+        self.sphinx_pyreverse_class = None
+        self.sphinx_pyreverse_show_ancestors = None
+        self.sphinx_pyreverse_all_ancestors = None
+        self.sphinx_pyreverse_show_associated = None
+        self.sphinx_pyreverse_all_associated = None
+        self.sphinx_pyreverse_show_builtin = None
+        self.sphinx_pyreverse_module_names = None
+        self.sphinx_pyreverse_only_classnames = None
+        self.sphinx_pyreverse_ignore = None
 
 
 class MockEnv(object):  # pylint: disable=missing-docstring

--- a/test/test_validate.py
+++ b/test/test_validate.py
@@ -178,6 +178,27 @@ class TestUMLGenerateDirective(TestUMLGenerateDirectiveBase):
         """ simply calls the setup function, ensuring no errors """
         self.assertEqual(sphinx_pyreverse.setup(Mock()), None)
 
+    def test_non_default_options(self):
+        """ Simply calls run with non-default pyreverse options
+
+        The intent here is to get 100% coverage and not test the functionality of
+        pyreverse itself, we trust that that is working as per contract """
+        state = MockState()
+        config = state.document.settings.env.config
+
+        instance = self.gen()
+
+        self.assertEqual(config.sphinx_pyreverse_output, "png")
+
+        # Set the config to non-default values
+        config.sphinx_pyreverse_output = "dot"
+
+        self.assertEqual(config.sphinx_pyreverse_output, "dot")
+
+        instance._build_command(  # pylint: disable=protected-access
+            "test_module", config=config
+        )
+
 
 class TestLogFixture(TestUMLGenerateDirectiveBase):
     """ Test logging related aspects of the plugin by capturing output """

--- a/test/test_validate.py
+++ b/test/test_validate.py
@@ -189,12 +189,47 @@ class TestUMLGenerateDirective(TestUMLGenerateDirectiveBase):
         instance = self.gen()
 
         self.assertEqual(config.sphinx_pyreverse_output, "png")
+        self.assertEqual(config.sphinx_pyreverse_filter_mode, None)
+        self.assertEqual(config.sphinx_pyreverse_class, None)
+        self.assertEqual(config.sphinx_pyreverse_show_ancestors, None)
+        self.assertEqual(config.sphinx_pyreverse_all_ancestors, None)
+        self.assertEqual(config.sphinx_pyreverse_show_associated, None)
+        self.assertEqual(config.sphinx_pyreverse_all_associated, None)
+        self.assertEqual(config.sphinx_pyreverse_show_builtin, None)
+        self.assertEqual(config.sphinx_pyreverse_module_names, None)
+        self.assertEqual(config.sphinx_pyreverse_only_classnames, None)
+        self.assertEqual(config.sphinx_pyreverse_ignore, None)
 
         # Set the config to non-default values
         config.sphinx_pyreverse_output = "dot"
+        config.sphinx_pyreverse_filter_mode = "ALL"
+        config.sphinx_pyreverse_class = "invalid-class"
+        config.sphinx_pyreverse_show_ancestors = "invalid-class"
+        config.sphinx_pyreverse_all_ancestors = True
+        config.sphinx_pyreverse_show_associated = 100
+        config.sphinx_pyreverse_all_associated = True
+        config.sphinx_pyreverse_show_builtin = True
+        config.sphinx_pyreverse_module_names = "y"
+        config.sphinx_pyreverse_ignore = "noexist.py,secondnoeexist.py"
 
         self.assertEqual(config.sphinx_pyreverse_output, "dot")
+        self.assertEqual(config.sphinx_pyreverse_filter_mode, "ALL")
+        self.assertEqual(config.sphinx_pyreverse_class, "invalid-class")
+        self.assertEqual(config.sphinx_pyreverse_show_ancestors, "invalid-class")
+        self.assertEqual(config.sphinx_pyreverse_all_ancestors, True)
+        self.assertEqual(config.sphinx_pyreverse_show_associated, 100)
+        self.assertEqual(config.sphinx_pyreverse_all_associated, True)
+        self.assertEqual(config.sphinx_pyreverse_show_builtin, True)
+        self.assertEqual(config.sphinx_pyreverse_module_names, "y")
+        self.assertEqual(config.sphinx_pyreverse_ignore, "noexist.py,secondnoeexist.py")
 
+        instance._build_command(  # pylint: disable=protected-access
+            "test_module", config=config
+        )
+
+        # disables --filter option, so run separately
+        config.sphinx_pyreverse_only_classnames = True
+        self.assertEqual(config.sphinx_pyreverse_only_classnames, True)
         instance._build_command(  # pylint: disable=protected-access
             "test_module", config=config
         )

--- a/test/test_validate.py
+++ b/test/test_validate.py
@@ -33,6 +33,8 @@ import tempfile
 
 import test.mock_subprocess
 import test.mock_pil
+from test.sphinx_test_util import MockState
+
 from mock import Mock
 import sphinx_pyreverse
 import sphinx_pyreverse.uml_generate_directive
@@ -57,22 +59,7 @@ class TestUMLGenerateDirectiveBase(unittest.TestCase):
     def gen(self):
         """ Constructs and returns a mocked UMLGenerateDirectiver instance """
 
-        class MockEnv(object):  # pylint: disable=missing-docstring
-            def __init__(self):  # pylint: disable=missing-docstring
-                self.srcdir = "."
-
-        class MockDocSettings(object):  # pylint: disable=missing-docstring
-            def __init__(self):  # pylint: disable=missing-docstring
-                self.env = MockEnv()
-
-        class MockDoc(object):  # pylint: disable=missing-docstring
-            def __init__(self):  # pylint: disable=missing-docstring
-                self.settings = MockDocSettings()
-                self.current_source = "."
-
-        class MockState(object):  # pylint: disable=missing-docstring
-            def __init__(self):  # pylint: disable=missing-docstring
-                self.document = MockDoc()
+        state = MockState()
 
         return sphinx_pyreverse.UMLGenerateDirective(
             name="test",
@@ -82,7 +69,7 @@ class TestUMLGenerateDirectiveBase(unittest.TestCase):
             lineno=None,
             content_offset=None,
             block_text=None,
-            state=MockState(),
+            state=state,
             state_machine=None,
         )
 


### PR DESCRIPTION
In this commit we attempt to address the issues discussed in #4 and #5.

First all configurations specified in `pyreverse --help` can now be configured in conf.py - see the updated README for details.

We also allow overrides of the 'uml' directive via an environment variable - it is the least-bad of all worlds. Until a decision is made to port from 'uml' to some other keyword. My concern is back-compatibility on that one.