### PR TITLE
test| Splits out the path-gen logic (no functional change) and puts i…

### DIFF
--- a/sphinx_pyreverse/uml_generate_directive.py
+++ b/sphinx_pyreverse/uml_generate_directive.py
@@ -148,18 +148,25 @@ class UMLGenerateDirective(Directive):
 
         return res
 
-    def generate_img(self, img_name, module_name, base_dir, src_dir, config):
-        """Resizes the image and returns a Sphinx image"""
+    def get_paths(self, img_name, module_name, base_dir, src_dir, config):
         path_from_base = os.path.join(self.DIR_NAME, "{1}_{0}.{2}").format(
             module_name, img_name, config.sphinx_pyreverse_output
         )
         # use relpath to get sub-directory of the main 'source' location
         src_base = os.path.relpath(base_dir, start=src_dir)
         uri = directives.uri(os.path.join(src_base, path_from_base))
+        output_file = os.path.join(base_dir, path_from_base)
+        return (uri, output_file)
+
+    def generate_img(self, img_name, module_name, base_dir, src_dir, config):
+        """Resizes the image and returns a Sphinx image"""
+        (uri, output_file) = self.get_paths(
+            img_name, module_name, base_dir, src_dir, config
+        )
         scale = 100
         max_width = 1000
         if IMAGE:
-            i = IMAGE.open(os.path.join(base_dir, path_from_base))
+            i = IMAGE.open(output_file)
             image_width = i.size[0]
             if image_width > max_width:
                 scale = max_width * scale / image_width

--- a/test/test_validate.py
+++ b/test/test_validate.py
@@ -328,3 +328,37 @@ class TestLogFixture(TestUMLGenerateDirectiveBase):
 
         # nothing should be printed to stdout or the logger
         assert buf.getvalue() == ""
+
+
+@pytest.mark.parametrize(
+    "module_address",
+    ["parent_only", "parent.submodule", "parent.submodule.nestedsubmodule"],
+)
+def test_module_paths(module_address):
+    state = MockState()
+
+    obj = sphinx_pyreverse.UMLGenerateDirective(
+        name="test",
+        arguments=[module_address, ":classes:", ":packages:"],
+        options=None,
+        content=None,
+        lineno=None,
+        content_offset=None,
+        block_text=None,
+        state=state,
+        state_machine=None,
+    )
+
+    doc = obj.state.document
+    env = doc.settings.env
+
+    uri, output_file = obj.get_paths(
+        img_name="IMG_NAME",
+        module_name=module_address,
+        base_dir="BASE_DIR/",
+        src_dir="SRC_DIR/",
+        config=env.config,
+    )
+
+    assert uri == f"../BASE_DIR/uml_images/IMG_NAME_{module_address}.png"
+    assert output_file == f"BASE_DIR/uml_images/IMG_NAME_{module_address}.png"


### PR DESCRIPTION
…t under explicit test